### PR TITLE
change biomass circle sizes

### DIFF
--- a/egon/templates/map.html
+++ b/egon/templates/map.html
@@ -139,23 +139,17 @@
                   //   * Blue, 20px circles when point count is less than 100
                   //   * Yellow, 30px circles when point count is between 100 and 750
                   //   * Pink, 40px circles when point count is greater than or equal to 750
-                  "circle-color": [
-                    "step",
-                    ["get", "{{layer.source_layer}}"],
-                    "#51bbd6",
-                    100,
-                    "#f1f075",
-                    750,
-                    "#f28cb1"
-                  ],
+                  "circle-color": "#51bbd6",
                   "circle-radius": [
                     "step",
                     ["get", "{{layer.source_layer}}"],
-                    20,
+                    15,
                     100,
-                    30,
-                    750,
-                    40
+                    20,
+                    500,
+                    25,
+                    1000,
+                    30
                   ]
                 }
               });


### PR DESCRIPTION
Is there a way to remove the value when it is equal to 0? Some states like Hamburg don't have any biomass facility and yet they are visible. I'm able to remove the circle but not the value.